### PR TITLE
Fixed lengths of functions

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -110,7 +110,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	 * based differences. Generally called by subclasses that generate a
 	 * HTML based diff and return an array of the changes to show in the diff.
 	 *
-	 * @return array An array of the generated chances, suitable for presentation in HTML.
+	 * @return array An array of the generated changes, suitable for presentation in HTML.
 	 */
 	public function render()
 	{
@@ -154,17 +154,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 				}
 
 				if($tag != $lastTag) {
-					$blocks[] = array(
-						'tag' => $tag,
-						'base' => array(
-							'offset' => $i1,
-							'lines' => array()
-						),
-						'changed' => array(
-							'offset' => $j1,
-							'lines' => array()
-						)
-					);
+					$blocks[] = $this->getDefaultArray($tag, $i1, $j1);
 					$lastBlock = count($blocks)-1;
 				}
 
@@ -296,5 +286,19 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	private function htmlSafe($string)
 	{
 		return htmlspecialchars($string, ENT_NOQUOTES, 'UTF-8');
+	}
+
+	private function getDefaultArray($tag, $i1, $j1){
+		return array(
+			'tag' => $tag,
+			'base' => array(
+				'offset' => $i1,
+				'lines' => array()
+			),
+			'changed' => array(
+				'offset' => $j1,
+				'lines' => array()
+			)
+		);
 	}
 }

--- a/lib/Diff/Renderer/Html/Inline.php
+++ b/lib/Diff/Renderer/Html/Inline.php
@@ -61,7 +61,53 @@ class Diff_Renderer_Html_Inline extends Diff_Renderer_Html_Array
 			return $html;
 		}
 
-		$html .= '<table class="Differences DifferencesInline">';
+		$html .= $this->generateTableHeader();
+
+		foreach($changes as $i => $blocks) {
+			// If this is a separate block, we're condensing code so output ...,
+			// indicating a significant portion of the code has been collapsed as
+			// it is the same
+			if($i > 0) {
+				$html .= $this->generateSkippedTable();
+			}
+
+			foreach($blocks as $change) {
+				$html .= '<tbody class="Change'.ucfirst($change['tag']).'">';
+				switch ($change['tag']){
+					// Equal changes should be shown on both sides of the diff
+					case 'equal':
+						$html .= $this->generateTableRowsEqual($change);
+						break;
+					// Added lines only on the right side
+					case 'insert':
+						$html .= $this->generateTableRowsInsert($change);
+						break;
+					// Show deleted lines only on the left side
+					case 'delete':
+						$html .= $this->generateTableRowsDelete($change);
+						break;
+					// Show modified lines on both sides
+					case 'replace':
+						$html .= $this->generateTableRowsReplace($change);
+						break;
+				}
+				$html .= '</tbody>';
+			}
+		}
+		$html .= '</table>';
+		return $html;
+	}
+
+	
+	/**
+	 * Generates a string representation of a predefined table and its head with
+	 * titles from options.
+	 * 
+	 * @return string Html code representation of the table's header.
+	 */
+	private function generateTableHeader()
+	{
+		$html = '<table class="Differences DifferencesInline">';
 		$html .= '<thead>';
 		$html .= '<tr>';
 		$html .= '<th>Old</th>';
@@ -69,78 +115,113 @@ class Diff_Renderer_Html_Inline extends Diff_Renderer_Html_Array
 		$html .= '<th>Differences</th>';
 		$html .= '</tr>';
 		$html .= '</thead>';
-		foreach($changes as $i => $blocks) {
-			// If this is a separate block, we're condensing code so output ...,
-			// indicating a significant portion of the code has been collapsed as
-			// it is the same
-			if($i > 0) {
-				$html .= '<tbody class="Skipped">';
-				$html .= '<th>&hellip;</th>';
-				$html .= '<th>&hellip;</th>';
-				$html .= '<td>&#xA0;</td>';
-				$html .= '</tbody>';
-			}
+		return $html;
+	}
 
-			foreach($blocks as $change) {
-				$html .= '<tbody class="Change'.ucfirst($change['tag']).'">';
-				// Equal changes should be shown on both sides of the diff
-				if($change['tag'] == 'equal') {
-					foreach($change['base']['lines'] as $no => $line) {
-						$fromLine = $change['base']['offset'] + $no + 1;
-						$toLine = $change['changed']['offset'] + $no + 1;
-						$html .= '<tr>';
-						$html .= '<th>'.$fromLine.'</th>';
-						$html .= '<th>'.$toLine.'</th>';
-						$html .= '<td class="Left">'.$line.'</td>';
-						$html .= '</tr>';
-					}
-				}
-				// Added lines only on the right side
-				else if($change['tag'] == 'insert') {
-					foreach($change['changed']['lines'] as $no => $line) {
-						$toLine = $change['changed']['offset'] + $no + 1;
-						$html .= '<tr>';
-						$html .= '<th>&#xA0;</th>';
-						$html .= '<th>'.$toLine.'</th>';
-						$html .= '<td class="Right"><ins>'.$line.'</ins>&#xA0;</td>';
-						$html .= '</tr>';
-					}
-				}
-				// Show deleted lines only on the left side
-				else if($change['tag'] == 'delete') {
-					foreach($change['base']['lines'] as $no => $line) {
-						$fromLine = $change['base']['offset'] + $no + 1;
-						$html .= '<tr>';
-						$html .= '<th>'.$fromLine.'</th>';
-						$html .= '<th>&#xA0;</th>';
-						$html .= '<td class="Left"><del>'.$line.'</del>&#xA0;</td>';
-						$html .= '</tr>';
-					}
-				}
-				// Show modified lines on both sides
-				else if($change['tag'] == 'replace') {
-					foreach($change['base']['lines'] as $no => $line) {
-						$fromLine = $change['base']['offset'] + $no + 1;
-						$html .= '<tr>';
-						$html .= '<th>'.$fromLine.'</th>';
-						$html .= '<th>&#xA0;</th>';
-						$html .= '<td class="Left"><span>'.$line.'</span></td>';
-						$html .= '</tr>';
-					}
-
-					foreach($change['changed']['lines'] as $no => $line) {
-						$toLine = $change['changed']['offset'] + $no + 1;
-						$html .= '<tr>';
-						$html .= '<th>&#xA0;</th>';
-						$html .= '<th>'.$toLine.'</th>';
-						$html .= '<td class="Right"><span>'.$line.'</span></td>';
-						$html .= '</tr>';
-					}
-				}
-				$html .= '</tbody>';
-			}
+	/**
+	 * Generates a string representation of empty table body.
+	 * 
+	 * @return string Html code representing empty table body.
+	 */
+	private function generateSkippedTable()
+	{
+		$html = '<tbody class="Skipped">';
+		$html .= '<th>&hellip;</th>';
+		$html .= '<th>&hellip;</th>';
+		$html .= '<td>&#xA0;</td>';
+		$html .= '</tbody>';
+		return $html;
+	}
+	
+	/**
+	 * Generates a string representation of one or more rows of a table of lines of text with no difference.
+	 * 
+	 * @param array &$change Array with data about changes.
+	 * @return string Html code representing one or more rows of text with no difference.
+	 */
+	private function generateTableRowsEqual(&$change)
+	{
+		$html = "";
+		foreach($change['base']['lines'] as $no => $line) {
+			$fromLine = $change['base']['offset'] + $no + 1;
+			$toLine = $change['changed']['offset'] + $no + 1;
+			$html .= '<tr>';
+			$html .= '<th>'.$fromLine.'</th>';
+			$html .= '<th>'.$toLine.'</th>';
+			$html .= '<td class="Left">'.$line.'</td>';
+			$html .= '</tr>';
 		}
-		$html .= '</table>';
+		return $html;
+	}
+
+	/**
+	 * Generates a string representation of one or more rows of a table of lines, where new text was added.
+	 * 
+	 * @param array &$change Array with data about changes.
+	 * @return string Html code representing one or more rows of added text.
+	 */
+	private function generateTableRowsInsert(&$change)
+	{
+		$html = "";
+		foreach($change['changed']['lines'] as $no => $line) {
+			$toLine = $change['changed']['offset'] + $no + 1;
+			$html .= '<tr>';
+			$html .= '<th>&#xA0;</th>';
+			$html .= '<th>'.$toLine.'</th>';
+			$html .= '<td class="Right"><ins>'.$line.'</ins>&#xA0;</td>';
+			$html .= '</tr>';
+		}
+		return $html;
+	}
+
+	/**
+	 * Generates a string representation of one or more rows of a table of lines, where text was removed.
+	 * 
+	 * @param array &$change Array with data about changes.
+	 * @return string Html code representing one or more rows of removed text.
+	 */
+	private function generateTableRowsDelete(&$change)
+	{
+		$html = "";
+		foreach($change['base']['lines'] as $no => $line) {
+			$fromLine = $change['base']['offset'] + $no + 1;
+			$html .= '<tr>';
+			$html .= '<th>'.$fromLine.'</th>';
+			$html .= '<th>&#xA0;</th>';
+			$html .= '<td class="Left"><del>'.$line.'</del>&#xA0;</td>';
+			$html .= '</tr>';
+		}
+		return $html;
+	}
+
+	/**
+	 * Generates a string representation of one or more rows of a table of lines, where text was partially modified.
+	 * 
+	 * @param array &$change Array with data about changes.
+	 * @return string Html code representing one or more rows of modified.
+	 */
+	private function generateTableRowsReplace(&$change)
+	{
+		$html = "";
+
+		foreach($change['base']['lines'] as $no => $line) {
+			$fromLine = $change['base']['offset'] + $no + 1;
+			$html .= '<tr>';
+			$html .= '<th>'.$fromLine.'</th>';
+			$html .= '<th>&#xA0;</th>';
+			$html .= '<td class="Left"><span>'.$line.'</span></td>';
+			$html .= '</tr>';
+		}
+
+		foreach($change['changed']['lines'] as $no => $line) {
+			$toLine = $change['changed']['offset'] + $no + 1;
+			$html .= '<tr>';
+			$html .= '<th>&#xA0;</th>';
+			$html .= '<th>'.$toLine.'</th>';
+			$html .= '<td class="Right"><span>'.$line.'</span></td>';
+			$html .= '</tr>';
+		}
+
 		return $html;
 	}
 }


### PR DESCRIPTION
Changed length of 3 functions so that they do not take more than 50 lines by separating them to smaller blocks.

Also found and fixed a bug in SideBySide renderer, where it would print wrong line count for modified lines on the right side.

I failed to change the render method in Diff_Renderer_Text_Context, because there was nothing that made logical sense to pull out to separate function and I did not want to remove empty lines as to not break readability of the code.