### PR TITLE
Fix #50.

### DIFF
--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -555,7 +555,7 @@ class SequenceMatcher
 
         if ($this->options['trimEqual']) {
             if ($opCodes['0']['0'] == 'equal') {
-                // Remove sequences at the start which are out of context.
+                // Remove sequences at the start of the text, but keep the context lines.
                 $opCodes['0'] = [
                     $opCodes['0']['0'],
                     max($opCodes['0']['1'], $opCodes['0']['2'] - $this->options['context']),
@@ -568,7 +568,7 @@ class SequenceMatcher
             $lastItem = count($opCodes) - 1;
             if ($opCodes[$lastItem]['0'] == 'equal') {
                 [$tag, $item1, $item2, $item3, $item4] = $opCodes[$lastItem];
-                // Remove sequences at the end which are out of context.
+                // Remove sequences at the end of the text, but keep the context lines.
                 $opCodes[$lastItem] = [
                     $tag,
                     $item1,
@@ -607,8 +607,8 @@ class SequenceMatcher
             ];
         }
 
-        if ($this->options['trimEqual'] || (!empty($group) && !(count($group) == 1 && $group[0][0] == 'equal'))) {
-            //Do not add the last sequences. They're out of context.
+        if (!$this->options['trimEqual'] || (!empty($group) && !(count($group) == 1 && $group[0][0] == 'equal'))) {
+            // Add the last sequences when !trimEqual || When there are no differences between both versions.
             $groups[] = $group;
         }
 

--- a/tests/Diff/Renderer/Text/TextRenderersTest.php
+++ b/tests/Diff/Renderer/Text/TextRenderersTest.php
@@ -95,4 +95,3 @@ class TextRendererTest extends TestCase
         $this->assertStringEqualsFile('tests/resources/ab.diff', $result);
     }
 }
-

--- a/tests/Diff/SequenceMatcherTest.php
+++ b/tests/Diff/SequenceMatcherTest.php
@@ -20,23 +20,47 @@ class SequenceMatcherTest extends TestCase
         parent::__construct($name, $data, $dataName);
     }
 
-    public function testGetGroupedOpCodes()
+    public function testGetGroupedOpCodesDefault()
     {
         // Test with default options.
-        $sequenceMatcher = new SequenceMatcher('54321ABXDE12345', '54321ABxDE12345');
-        $this->assertEquals(
-            [[['equal', 4, 7, 4, 7], ['replace', 7, 8, 7, 8], ['equal', 8, 11, 8, 11]]],
-            $sequenceMatcher->getGroupedOpCodes()
+        $sequenceMatcher = new SequenceMatcher(
+            '54321ABXDE12345',
+            '54321ABxDE12345'
         );
 
+        $this->assertEquals(
+            [
+                [
+                    ['equal', 4, 7, 4, 7], ['replace', 7, 8, 7, 8], ['equal', 8, 11, 8, 11]
+                ]
+            ],
+            $sequenceMatcher->getGroupedOpCodes()
+        );
+    }
+
+    public function testGetGroupedOpCodesTrimEqualFalse()
+    {
         // Test with trimEqual disabled.
-        $sequenceMatcher = new SequenceMatcher('54321ABXDE12345', '54321ABxDE12345', ['trimEqual' => false]);
-        $this->assertEquals(
-            [[['equal', 0, 3, 0, 3]], [['equal', 4, 7, 4, 7], ['replace', 7, 8, 7, 8], ['equal', 8, 11, 8, 11]]],
-            $sequenceMatcher->getGroupedOpCodes()
+        // First and last context lines of the sequences are included.
+        $sequenceMatcher = new SequenceMatcher(
+            '54321ABXDE12345',
+            '54321ABxDE12345',
+            ['trimEqual' => false]
         );
 
-        // Test with ignoreWhitespace enabled.
+        $this->assertEquals(
+            [
+                [['equal', 0, 3, 0, 3]],
+                [['equal', 4, 7, 4, 7], ['replace', 7, 8, 7, 8], ['equal', 8, 11, 8, 11]],
+                [['equal', 12, 15, 12, 15]],
+            ],
+            $sequenceMatcher->getGroupedOpCodes()
+        );
+    }
+
+    public function testGetGroupedOpCodesIgnoreWhitespaceTrue()
+    {
+        // Test with ignoreWhitespace enabled. Both sequences are considered to be the same.
         // Note: The sequenceMatcher evaluates the string character by character. Option ignoreWhitespace will ignore
         //       if the difference if the character is a tab in one sequence and a space in the other.
         $sequenceMatcher = new SequenceMatcher(
@@ -44,15 +68,24 @@ class SequenceMatcherTest extends TestCase
             " 54321ABXDE12345\t",
             ['ignoreWhitespace' => true]
         );
+
         $this->assertEquals(
-            [[['equal', 14, 17, 14, 17]]],
+            [],
             $sequenceMatcher->getGroupedOpCodes()
         );
+    }
 
-        // Test with ignoreCase enabled.
-        $sequenceMatcher = new SequenceMatcher('54321ABXDE12345', '54321ABxDE12345', ['ignoreCase' => true]);
+    public function testGetGroupedOpCodesIgnoreCaseTrue()
+    {
+        // Test with ignoreCase enabled. Both sequences are considered to be the same.
+        $sequenceMatcher = new SequenceMatcher(
+            '54321ABXDE12345',
+            '54321ABxDE12345',
+            ['ignoreCase' => true]
+        );
+
         $this->assertEquals(
-            [[['equal', 12, 15, 12, 15]]],
+            [],
             $sequenceMatcher->getGroupedOpCodes()
         );
     }


### PR DESCRIPTION
Fix #50 
First or last x lines of text are shown even when there's no difference between the two compared texts.