### PR TITLE
Fixes #64 - maxLineMarkerWidth only calculated for input format plain.

### DIFF
--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -35,8 +35,8 @@ class MainRenderer extends MainRendererAbstract
      *
      * This method is called by the renderers which extends this class.
      *
-     * @param array  $changes     Contains the op-codes about the differences between version1 and version2.
-     * @param object $subRenderer Renderer which is subClass of this class.
+     * @param   array   $changes      Contains the op-codes about the differences between version1 and version2.
+     * @param   object  $subRenderer  Renderer which is subClass of this class.
      *
      * @return string|false String representation of the differences or false when versions are identical.
      */
@@ -56,15 +56,12 @@ class MainRenderer extends MainRendererAbstract
                 $output .= $subRenderer->generateSkippedLines();
             }
 
-            if ($this->options['format'] == 'plain') {
-                $this->maxLineMarkerWidth =
-                    max(
-                        strlen($this->options['insertMarkers'][0]),
-                        strlen($this->options['deleteMarkers'][0]),
-                        strlen($this->options['equalityMarkers'][0]),
-                        strlen($this->options['equalityMarkers'][1])
-                    );
-            }
+            $this->maxLineMarkerWidth = max(
+                strlen($this->options['insertMarkers'][0]),
+                strlen($this->options['deleteMarkers'][0]),
+                strlen($this->options['equalityMarkers'][0]),
+                strlen($this->options['equalityMarkers'][1])
+            );
 
             foreach ($blocks as $change) {
                 $output .= $subRenderer->generateBlockHeader($change);
@@ -184,11 +181,11 @@ class MainRenderer extends MainRendererAbstract
      * New => "ab123fg"   End marker inserted at position 6
      * </pre>
      *
-     * @param array $oldText  Collection of lines of old text.
-     * @param array $newText  Collection of lines of new text.
-     * @param int   $startOld First line of the block in old to replace.
-     * @param int   $endOld   last line of the block in old to replace.
-     * @param int   $startNew First line of the block in new to replace.
+     * @param   array  $oldText   Collection of lines of old text.
+     * @param   array  $newText   Collection of lines of new text.
+     * @param   int    $startOld  First line of the block in old to replace.
+     * @param   int    $endOld    last line of the block in old to replace.
+     * @param   int    $startNew  First line of the block in new to replace.
      */
     private function markInlineChange(array &$oldText, array &$newText, int $startOld, int $endOld, int $startNew)
     {
@@ -231,8 +228,8 @@ class MainRenderer extends MainRendererAbstract
      * The second element defines the last (starting at -0) character from the end of the old string which is different.
      *
      *
-     * @param string $oldString The first string to compare.
-     * @param string $newString The second string to compare.
+     * @param   string  $oldString  The first string to compare.
+     * @param   string  $newString  The second string to compare.
      *
      * @return array Array containing the starting position (0 by default) and the ending position (-1 by default)
      */
@@ -270,10 +267,10 @@ class MainRenderer extends MainRendererAbstract
      *
      * The index of the last element of the array is always returned.
      *
-     * @param array   $blocks    The array which keeps the changes for the HTML renderer.
-     * @param string  $tag       Kind of difference.
-     * @param integer $lineInOld Start of block in "old".
-     * @param integer $lineInNew Start of block in "new".
+     * @param   array    $blocks     The array which keeps the changes for the HTML renderer.
+     * @param   string   $tag        Kind of difference.
+     * @param   integer  $lineInOld  Start of block in "old".
+     * @param   integer  $lineInNew  Start of block in "new".
      *
      * @return int The index of the last element.
      */
@@ -306,7 +303,7 @@ class MainRenderer extends MainRendererAbstract
      * This involves replacing tab characters with spaces, making the HTML safe for output by ensuring that double
      * spaces are replaced with &nbsp; etc.
      *
-     * @param array $strings Array of strings to format.
+     * @param   array  $strings  Array of strings to format.
      *
      * @return array Array of formatted strings.
      */

--- a/lib/jblond/Diff/Renderer/Text/InlineCli.php
+++ b/lib/jblond/Diff/Renderer/Text/InlineCli.php
@@ -13,12 +13,12 @@ use jblond\Diff\Renderer\SubRendererInterface;
  *
  * PHP version 7.2 or greater
  *
- * @package     jblond\Diff\Renderer\Text
- * @author      Ferry Cools <info@DigiLive.nl>
+ * @package         jblond\Diff\Renderer\Text
+ * @author          Ferry Cools <info@DigiLive.nl>
  * @copyright   (c) 2020 Ferry Cools
- * @license     New BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version     2.2.1
- * @link        https://github.com/JBlond/php-diff
+ * @license         New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @version         2.2.1
+ * @link            https://github.com/JBlond/php-diff
  */
 class InlineCli extends MainRenderer implements SubRendererInterface
 {
@@ -31,7 +31,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * InlineCli constructor.
      *
-     * @param array $options Custom defined options for the inline diff renderer.
+     * @param   array  $options  Custom defined options for the inline diff renderer.
      *
      * @see Inline::$subOptions
      */
@@ -67,7 +67,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation of the start of a block.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of lines.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of lines.
      *
      * @return string Start of the diff view.
      */
@@ -89,14 +89,17 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation lines without differences between the two versions.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of lines.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of lines.
      *
      * @return string Text with no difference.
      */
     public function generateLinesEqual(array $changes): string
     {
         $returnValue = '';
-        $padding     = str_repeat(' ', $this->maxLineMarkerWidth - strlen($this->options['equalityMarkers'][0]));
+        $padding     = str_repeat(
+            ' ',
+            max($this->maxLineMarkerWidth - strlen($this->options['equalityMarkers'][0]), 0)
+        );
 
         foreach ($changes['base']['lines'] as $line) {
             $returnValue .= $this->options['equalityMarkers'][0] . $padding . '|' . $line . "\n";
@@ -108,7 +111,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation of lines that are added to the 2nd version.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string Added text.
      */
@@ -116,7 +119,10 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     {
         $colorize    = new CliColors();
         $returnValue = '';
-        $padding     = str_repeat(' ', $this->maxLineMarkerWidth - strlen($this->options['insertMarkers'][0]));
+        $padding     = str_repeat(
+            ' ',
+            max($this->maxLineMarkerWidth - strlen($this->options['insertMarkers'][0]), 0)
+        );
 
         foreach ($changes['changed']['lines'] as $line) {
             if ($this->options['cliColor']) {
@@ -132,7 +138,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation of lines that are removed from the 2nd version.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string Removed text.
      */
@@ -140,7 +146,10 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     {
         $colorize    = new CliColors();
         $returnValue = '';
-        $padding     = str_repeat(' ', $this->maxLineMarkerWidth - strlen($this->options['deleteMarkers'][0]));
+        $padding     = str_repeat(
+            ' ',
+            max($this->maxLineMarkerWidth - strlen($this->options['deleteMarkers'][0]), 0)
+        );
 
         foreach ($changes['base']['lines'] as $line) {
             if ($this->options['cliColor']) {
@@ -156,7 +165,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation of lines that are partially modified.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string Modified text.
      */
@@ -179,10 +188,10 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Merge the changes between two lines together and mark these changes.
      *
-     * @param array        $baseLines       Lines of version 1.
-     * @param array        $changedLines    Lines of version 2.
-     * @param array|null[] $deleteColors    Fore- and background colors of part that is removed from the 2nd version.
-     * @param array|null[] $insertColors    Fore- and background colors of part that is added to the 2nd version.
+     * @param   array         $baseLines     Lines of version 1.
+     * @param   array         $changedLines  Lines of version 2.
+     * @param   array|null[]  $deleteColors  Fore- and background colors of part that is removed from the 2nd version.
+     * @param   array|null[]  $insertColors  Fore- and background colors of part that is added to the 2nd version.
      *
      * Option $deleteColors and $insertColors only have affect when this class's cliColors option is set to true.
      *
@@ -194,7 +203,11 @@ class InlineCli extends MainRenderer implements SubRendererInterface
         array $deleteColors = [null, null],
         array $insertColors = [null, null]
     ): array {
-        $padding = str_repeat(' ', $this->maxLineMarkerWidth - strlen($this->options['equalityMarkers'][1]));
+        $padding = str_repeat(
+            ' ',
+            max($this->maxLineMarkerWidth - strlen($this->options['equalityMarkers'][1]), 0)
+        );
+
         if ($this->options['cliColor']) {
             $colorize = new CliColors();
         }
@@ -233,7 +246,7 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * Generate a string representation of the end of a block.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string End of the block
      */


### PR DESCRIPTION
- Calculation of maxLineMarkerWidth independent of input format.
- Second parameter of string repeat function minimizes to 0.
- Code cleanup.