### PR TITLE
Fix: Html SideBySide renders equal lines of version 1 at both sides.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,46 +2,47 @@
 
 ## next
 
-- Fix: Unified Cli renderer options incompatible with Main renderer options
-- Fix: Calculation of maxLineMarkerWidth independent of input format.
+- Add: Change log.
+- Fix: Html SideBySide renders equal lines of version 1 at both sides (Option ignoreCase).
 - Fix: Second parameter of string repeat function minimizes to 0.
-- added change log
+- Fix: #60 - Unified Cli renderer options incompatible with Main renderer options
+- Fix: #64 - Calculation of maxLineMarkerWidth independent of input format.
 
 ## 2.2.1 (2020-08-06)
 
-- This release fixed #58 - Side by side diff shows empty diff
+- Fix: #58 - Side by side diff shows empty diff
 
 ## 2.2.0 (2020-07-23)
 
-- adds an option for a custom override renderer. #53
-- add the feature to not have an output when there are not changes between the compared strings / files. #52 #54
+- Add: Option for a custom override renderer. #53
+- Add: No output when there are no differences between the compared strings / files. #52 #54
 
 ## 2.1.1 (2020-07-17)
 
-- This release fixes #50 that equal text files produced an output, but shouldn't.
+- Fix: #50 - Renderers produce output with equal texts, while they shouldn't.
 
 ## 2.1.0 (2020-07-13)
 
-- This release adds cli non colored output. This allows it to be piped.
+- Add: Cli uncolored output. This allows it to be piped.
 
 ## 2.0.0 (2020-07-09)
 
-- This version mainly adds Unified Commandline colored output
-- using semantic versioning
+- Add: Unified Commandline colored output.
+- Change: switch to semantic versioning.
 
 ## 1.18 (2020-07-01)
 
-- Added a dark theme to the example
-- Fix: Avoid variables with short names (some)
+- Add: A dark theme to the example.
+- Fix: Avoid variables with short names (some).
 
 ## 1.17 (2020-06-08)
 
-- Bugfix release for #32
+- Fix #32 - Side by side diff shows only partially all deleted lines.
 
 ## 1.16 (2020-03-02)
 
 - Features
-    - Add trimEqual option
+    - Add: option trimEqual.
 
 - Fixes
     - Fix PHPMD Violation.
@@ -49,69 +50,69 @@
 
 ## 1.15 (2020-01-24)
 
-- Added new Unified HTML
-- code clean up
+- Add: New Unified HTML.
+- Fix: Code clean up.
 
 ## 1.14 (2019-12-03)
 
-- Removed some old dead code
+- Fix: Remove some old dead code.
 
 ## 1.13 (2019-10-08)
 
-- switched to PSR12
+- Change: Switch to PSR12.
 
 ## 1.12 (2019-03-18)
 
-- Update composer
-- PSR2 fixes
+- Change: Update Composer Configuration.
+- Fix: PSR-2 conventions.
 
 ## 1.11 (2019-02-22)
 
-- code clean up
-- Corrected composer autoloader for unit tests
+- Fix: Code clean up.
+- Fix: Composer autoloader for unit tests.
 
 ## 1.10 (2019-02-20)
 
-- code clean up
+- Fix: Code clean up.
 
 ## 1.9 (2019-02-19)
 
-- code cleaning
+- Fix: Code clean up.
 
 ## 1.8
 
-- Readme updates
-- unit test fixes
+- Change: Update Readme and bumping versions.
+- Fix: Moved include of Autoloader from the constructor to global space for HtmlArray unit test.
 
 ## 1.7
 
-- PSR2 code alignment
+- Fix: PSR-2 code alignment.
 
 ## 1.6
 
-- php-diff requires now PHP 7.1
-- Added return type hinting
+- Change: Bump required version of PHP to v7.1.
+- Add: Return type hinting.
 
 ## 1.5 (2019-01-15)
 
-- Fixed some autoloader naming issues
+- Fix: Autoloader naming issues.
 
 ## 1.4 (2019-01-14)
 
-- PSR4 namespace support added
+- Add: PSR-4 namespace support.
 
 ## 1.3 (2019-01-11)
 
-- PHP methods contained too much logic. That has been simplified.
+- Fix: PHP methods contained too much logic. That has been simplified.
 
 ## 1.2 (2018-01-23)
 
-- Added support for custom titles
+- Add: Support for custom titles.
 
 ## 1.1 (2017-05-06)
 
-- Some fixes with chinese characters
+- Fix: Wrong highlight area for chinese characters.
 
 ## 1.0 
 
-- initial version
+- Initial version.

--- a/lib/jblond/Diff/Renderer/Html/SideBySide.php
+++ b/lib/jblond/Diff/Renderer/Html/SideBySide.php
@@ -12,14 +12,14 @@ use jblond\Diff\Renderer\SubRendererInterface;
  *
  * PHP version 7.2 or greater
  *
- * @package     jblond\Diff\Renderer\Html
- * @author      Chris Boulton <chris.boulton@interspire.com>
- * @author      Mario Brandt <leet31337@web.de>
- * @author      Ferry Cools <info@DigiLive.nl>
+ * @package         jblond\Diff\Renderer\Html
+ * @author          Chris Boulton <chris.boulton@interspire.com>
+ * @author          Mario Brandt <leet31337@web.de>
+ * @author          Ferry Cools <info@DigiLive.nl>
  * @copyright   (c) 2009 Chris Boulton
- * @license     New BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version     2.2.1
- * @link        https://github.com/JBlond/php-diff
+ * @license         New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @version         2.2.1
+ * @link            https://github.com/JBlond/php-diff
  */
 class SideBySide extends MainRenderer implements SubRendererInterface
 {
@@ -43,7 +43,7 @@ class SideBySide extends MainRenderer implements SubRendererInterface
     /**
      * SideBySide constructor.
      *
-     * @param array $options Custom defined options for the inline diff renderer.
+     * @param   array  $options  Custom defined options for the inline diff renderer.
      *
      * @see Inline::$subOptions
      */
@@ -103,7 +103,10 @@ HTML;
     /**
      * Generate a string representation of table rows with lines without differences between both versions.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks.
+     * Note: Depending on the options, lines can be marked as being equal, while the contents actually differ.
+     * (E.g. ignoreWhitespace and ignoreCase)
+     *
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks.
      *
      * @return string HTML code representing table rows showing text with no difference.
      */
@@ -111,7 +114,7 @@ HTML;
     {
         $html = '';
 
-        foreach ($changes['base']['lines'] as $lineNo => $line) {
+        foreach ($changes['base']['lines'] as $lineNo => $baseLine) {
             $fromLine = $changes['base']['offset'] + $lineNo + 1;
             $toLine   = $changes['changed']['offset'] + $lineNo + 1;
 
@@ -119,11 +122,11 @@ HTML;
 <tr>
     <th>$fromLine</th>
     <td class="Left">
-        <span>$line</span>
+        <span>$baseLine</span>
     </td>
     <th>$toLine</th>
     <td class="Right">
-        <span>$line</span>
+        <span>{$changes['changed']['lines'][$lineNo]}</span>
     </td>
 </tr>
 HTML;
@@ -135,7 +138,7 @@ HTML;
     /**
      * Generates a string representation of table rows with lines that are added to the 2nd version.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string HTML code representing table rows showing with added text.
      */
@@ -164,7 +167,7 @@ HTML;
     /**
      * Generates a string representation of table rows with lines that are removed from the 2nd version.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string HTML code representing table rows showing removed text.
      */
@@ -193,7 +196,7 @@ HTML;
     /**
      * Generates a string representation of table rows with lines that are partially modified.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string Html code representing table rows showing modified text.
      */
@@ -264,7 +267,7 @@ HTML;
     /**
      * Generate a string representation of the start of a block.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string Start of the diff view.
      */
@@ -276,7 +279,7 @@ HTML;
     /**
      * Generate a string representation of the end of a block.
      *
-     * @param array $changes Contains the op-codes about the changes between two blocks of text.
+     * @param   array  $changes  Contains the op-codes about the changes between two blocks of text.
      *
      * @return string End of the block.
      */


### PR DESCRIPTION
When option ignoreCase is true, the renderer should show both versions.