### PR TITLE
Fix #83 - Lines not properly marked

### DIFF
--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -310,26 +310,24 @@ class MainRenderer extends MainRendererAbstract
 
             // Determine the start and end position of the line difference.
             [$start, $end] = $this->getOuterChange($oldString, $newString);
-            if ($start != 0 || $end != 0) {
-                // Changes between the lines exist.
-                // Add markers around the changed character sequence in the old string.
-                $sequenceEnd = mb_strlen($oldString) + $end;
-                $oldString   =
-                    mb_substr($oldString, 0, $start) . "\0" .
-                    mb_substr($oldString, $start, $sequenceEnd - $start) . "\1" .
-                    mb_substr($oldString, $sequenceEnd);
+            // Changes between the lines exist.
+            // Add markers around the changed character sequence in the old string.
+            $sequenceEnd = mb_strlen($oldString) + $end;
+            $oldString
+                         = mb_substr($oldString, 0, $start) . "\0" .
+                mb_substr($oldString, $start, $sequenceEnd - $start) . "\1" .
+                mb_substr($oldString, $sequenceEnd);
 
-                // Add markers around the changed character sequence in the new string.
-                $sequenceEnd = mb_strlen($newString) + $end;
-                $newString   =
-                    mb_substr($newString, 0, $start) . "\0" .
-                    mb_substr($newString, $start, $sequenceEnd - $start) . "\1" .
-                    mb_substr($newString, $sequenceEnd);
+            // Add markers around the changed character sequence in the new string.
+            $sequenceEnd = mb_strlen($newString) + $end;
+            $newString
+                         = mb_substr($newString, 0, $start) . "\0" .
+                mb_substr($newString, $start, $sequenceEnd - $start) . "\1" .
+                mb_substr($newString, $sequenceEnd);
 
-                // Overwrite the strings in the old and new text so the changed lines include the markers.
-                $oldText[$startOld + $iterator] = $oldString;
-                $newText[$startNew + $iterator] = $newString;
-            }
+            // Overwrite the strings in the old and new text so the changed lines include the markers.
+            $oldText[$startOld + $iterator] = $oldString;
+            $newText[$startNew + $iterator] = $newString;
         }
     }
 


### PR DESCRIPTION
Fix #83 - Lines not properly marked

If a line is different at the other version from the first to the last
character, the line isn't marked when inlineMarking is set to
CHANGE_LEVEL_LINE.