### PR TITLE
php-diff-82

### DIFF
--- a/example/dark-theme.css
+++ b/example/dark-theme.css
@@ -97,6 +97,19 @@ a, a:visited {
     background: #EEBB00;
 }
 
+.DifferencesSideBySide .ChangeIgnore .Left,
+.DifferencesSideBySide .ChangeIgnore .Right {
+    background: #FBF2BF;
+}
+
+.DifferencesSideBySide .ChangeIgnore .Left.Ignore {
+    background: #4B4C57;
+}
+
+.DifferencesSideBySide .ChangeIgnore .Right.Ignore {
+    background: #4B4C57;
+}
+
 /*
  * HTML Unified Diff
  */

--- a/example/example.php
+++ b/example/example.php
@@ -20,6 +20,7 @@ $diffOptions = [
     'trimEqual'        => false,
     'ignoreWhitespace' => true,
     'ignoreCase'       => true,
+    'ignoreLines'      => Diff::DIFF_IGNORE_LINE_EMPTY,
 ];
 
 // Choose one of the initializations.

--- a/example/styles.css
+++ b/example/styles.css
@@ -6,8 +6,8 @@ body {
 }
 
 pre {
-    width:    100%;
     overflow: auto;
+    width:    100%;
 }
 
 /*
@@ -15,34 +15,34 @@ pre {
  */
 
 .Differences {
-    width:           100%;
     border-collapse: collapse;
     border-spacing:  0;
     empty-cells:     show;
+    width:           100%;
 }
 
 .Differences thead th {
-    text-align:    left;
-    border-bottom: 1px solid #000000;
     background:    #AAAAAA;
+    border-bottom: 1px solid #000000;
     color:         #000000;
     padding:       4px;
+    text-align:    left;
 }
 
 .Differences tbody th {
-    text-align:     right;
     background:     #CCCCCC;
-    width:          4em;
-    padding:        1px 2px;
     border-right:   1px solid #000000;
-    vertical-align: top;
     font-size:      13px;
+    padding:        1px 2px;
+    text-align:     right;
+    vertical-align: top;
+    width:          4em;
 }
 
 .Differences td {
-    padding:     1px 2px;
     font-family: Consolas, monospace;
     font-size:   13px;
+    padding:     1px 2px;
 }
 
 .Differences .Skipped {
@@ -75,6 +75,19 @@ pre {
 
 .DifferencesSideBySide .ChangeReplace .Right {
     background: #FFDD88;
+}
+
+.DifferencesSideBySide .ChangeIgnore .Left,
+.DifferencesSideBySide .ChangeIgnore .Right {
+    background: #FBF2BF;
+}
+
+.DifferencesSideBySide .ChangeIgnore .Left.Ignore {
+    background: #F7F7F7;
+}
+
+.DifferencesSideBySide .ChangeIgnore .Right.Ignore {
+    background: #F7F7F7;
 }
 
 .Differences ins,

--- a/lib/jblond/Diff.php
+++ b/lib/jblond/Diff.php
@@ -46,8 +46,7 @@ class Diff
     private $groupedCodes;
 
     /**
-     * @var array<string, string> Associative array containing the default options available
-     *                    for the diff class and their default value.
+     * @var array Associative array containing the default options available for the diff class and their default value.
      *
      *              - context           The amount of lines to include around blocks that differ.
      *              - trimEqual         Strip blocks of equal lines from the start and end of the text.

--- a/lib/jblond/Diff.php
+++ b/lib/jblond/Diff.php
@@ -29,6 +29,18 @@ use OutOfRangeException;
 class Diff
 {
     /**
+     * Flag to disable ignore of successive empty/blank lines.
+     */
+    public const DIFF_IGNORE_LINE_NONE = 0;
+    /**
+     * Flag to ignore successive empty lines.
+     */
+    public const DIFF_IGNORE_LINE_EMPTY = 1;
+    /**
+     * Flag to ignore successive blank lines. (Lines which contain no or only non printable characters.)
+     */
+    public const DIFF_IGNORE_LINE_BLANK = 2;
+    /**
      * @var array   The first version to compare.
      *              Each element contains a line of this string.
      */
@@ -48,18 +60,20 @@ class Diff
     /**
      * @var array Associative array containing the default options available for the diff class and their default value.
      *
-     *              - context           The amount of lines to include around blocks that differ.
-     *              - trimEqual         Strip blocks of equal lines from the start and end of the text.
-     *              - ignoreWhitespace  When true, tabs and spaces are ignored while comparing.
-     *                                  The spacing of version1 is leading.
-     *              - ignoreCase        When true, character casing is ignored while comparing.
-     *                                  The casing of version1 is leading.
+     *            - context           The amount of lines to include around blocks that differ.
+     *            - trimEqual         Strip blocks of equal lines from the start and end of the text.
+     *            - ignoreWhitespace  True to ignore differences in tabs and spaces.
+     *            - ignoreCase        True to ignore differences in character casing.
+     *            - ignoreLines       0: None.
+     *                                1: Ignore empty lines.
+     *                                2: Ignore blank lines.
      */
     private $defaultOptions = [
         'context'          => 3,
         'trimEqual'        => true,
         'ignoreWhitespace' => false,
         'ignoreCase'       => false,
+        'ignoreLines'      => self::DIFF_IGNORE_LINE_NONE,
     ];
 
     /**

--- a/lib/jblond/Diff/Renderer/Html/SideBySide.php
+++ b/lib/jblond/Diff/Renderer/Html/SideBySide.php
@@ -282,4 +282,70 @@ HTML;
     {
         return '</table>';
     }
+
+    /**
+     * @inheritDoc
+     *
+     * @return string Html code representing table rows showing ignored text.
+     */
+    public function generateLinesIgnore(array $changes): string
+    {
+        $html = '';
+
+        // Is below comparison result ever false?
+        if (count($changes['base']['lines']) >= count($changes['changed']['lines'])) {
+            foreach ($changes['base']['lines'] as $lineNo => $line) {
+                $fromLine    = $changes['base']['offset'] + $lineNo + 1;
+                $toLine      = '&nbsp;';
+                $changedLine = '&nbsp;';
+                if (isset($changes['changed']['lines'][$lineNo])) {
+                    $toLine      = $changes['changed']['offset'] + $lineNo + 1;
+                    $changedLine = $changes['changed']['lines'][$lineNo];
+                }
+
+                $html .= <<<HTML
+<tr>
+    <th>$fromLine</th>
+    <td class="Left">
+        <span>$line</span>
+    </td>
+    <th>$toLine</th>
+    <td class="Right Ignore">
+        <span>$changedLine</span>
+    </td>
+</tr>
+HTML;
+            }
+
+            return $html;
+        }
+
+        foreach ($changes['changed']['lines'] as $lineNo => $changedLine) {
+            $toLine   = $changes['changed']['offset'] + $lineNo + 1;
+            $fromLine = '&nbsp;';
+            $line     = '&nbsp;';
+            if (isset($changes['base']['lines'][$lineNo])) {
+                $fromLine = $changes['base']['offset'] + $lineNo + 1;
+                $line     = $changes['base']['lines'][$lineNo];
+            }
+
+            $line        = str_replace(["\0", "\1"], $this->options['deleteMarkers'], $line);
+            $changedLine = str_replace(["\0", "\1"], $this->options['insertMarkers'], $changedLine);
+
+            $html .= <<<HTML
+<tr>
+    <th>$fromLine</th>
+    <td class="Left Ignore">
+        <span>$line</span>
+    </td>
+    <th>$toLine</th>
+    <td class="Right">
+        <span>$changedLine</span>
+    </td>
+</tr>
+HTML;
+        }
+
+        return $html;
+    }
 }

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -124,7 +124,7 @@ class MainRenderer extends MainRendererAbstract
                  * 4 - The end line in the second sequence.
                  *
                  * The different types of tags include:
-                 * replace - The string from $startOld to $endOld in $oldText should be replaced by
+                 * replace - The string in $oldText from $startOld to $endOld, should be replaced by
                  *           the string in $newText from $startNew to $endNew.
                  * delete  - The string in $oldText from $startOld to $endNew should be deleted.
                  * insert  - The string in $newText from $startNew to $endNew should be inserted at $startOld in
@@ -291,7 +291,7 @@ class MainRenderer extends MainRendererAbstract
      * E.g.
      * <pre>
      *         1234567
-     * OLd => "abcdefg" Start marker inserted at position 3
+     * Old => "abcdefg" Start marker inserted at position 3
      * New => "ab123fg"   End marker inserted at position 6
      * </pre>
      *

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -146,23 +146,23 @@ class MainRenderer extends MainRendererAbstract
                 $oldBlock = $this->formatLines(array_slice($oldText, $startOld, $blockSizeOld));
                 $newBlock = $this->formatLines(array_slice($newText, $startNew, $blockSizeNew));
 
-                if ($tag == 'equal') {
-                    // Old block equals New block
+                if ($tag != 'delete' && $tag != 'insert') {
+                    // Old block "equals" New block or is replaced.
                     $blocks[$lastBlock]['base']['lines']    += $oldBlock;
                     $blocks[$lastBlock]['changed']['lines'] += $newBlock;
                     continue;
                 }
 
-                if ($tag == 'replace' || $tag == 'delete') {
-                    // Inline differences or old block doesn't exist in the new text.
+                if ($tag == 'delete') {
+                    // Block of version1 doesn't exist in version2.
                     $blocks[$lastBlock]['base']['lines'] += $oldBlock;
+                    continue;
                 }
 
-                if ($tag == 'replace' || $tag == 'insert') {
-                    // Inline differences or the new block doesn't exist in the old text.
-                    $blocks[$lastBlock]['changed']['lines'] += $newBlock;
-                }
+                // Block of version2 doesn't exist in version1.
+                $blocks[$lastBlock]['changed']['lines'] += $newBlock;
             }
+
             $changes[] = $blocks;
         }
 

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -80,6 +80,10 @@ class MainRenderer extends MainRendererAbstract
                     case 'replace':
                         $output .= $subRenderer->generateLinesReplace($change);
                         break;
+                    case 'ignore':
+                        // TODO: Keep backward compatible with renderers?
+                        $output .= $subRenderer->generateLinesIgnore($change);
+                        break;
                 }
 
                 $output .= $subRenderer->generateBlockFooter($change);
@@ -130,6 +134,8 @@ class MainRenderer extends MainRendererAbstract
                  * insert  - The string in $newText from $startNew to $endNew should be inserted at $startOld in
                  *           $oldText.
                  * equal   - The two strings with the specified ranges are equal.
+                 * ignore  - The string in $oldText from $startOld to $endOld and
+                 *           the string in $newText from $startNew to $endNew are different, but considered to be equal.
                  */
 
                 $blockSizeOld = $endOld - $startOld;

--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -46,17 +46,12 @@ class SequenceMatcher
     private $b2j = [];
 
     /**
-     * @var array
-     */
-    private $options = [];
-
-    /**
-     * @var null|array
+     * @var array A list of all of the op-codes for the differences between the compared strings.
      */
     private $opCodes;
 
     /**
-     * @var null|array
+     * @var array A nested set of arrays for all of the matching sub-sequences the compared strings.
      */
     private $matchingBlocks;
 
@@ -72,9 +67,8 @@ class SequenceMatcher
     ];
 
     /**
-     * The constructor. With the sequences being passed, they'll be set for the
-     * sequence matcher and it will perform a basic cleanup & calculate junk
-     * elements.
+     * The constructor. With the sequences being passed, they'll be set for the sequence matcher and it will perform a
+     * basic cleanup & calculate junk elements.
      *
      * @param   string|array       $old           A string or array containing the lines to compare against.
      * @param   string|array       $new           A string or array containing the lines to compare.
@@ -295,11 +289,9 @@ class SequenceMatcher
     }
 
     /**
-     * Return a list of all of the op codes for the differences between the
-     * two strings.
+     * Return a list of all of the op codes for the differences between the two strings.
      *
-     * The nested array returned contains an array describing the op code
-     * which includes:
+     * The nested array returned contains an array describing the op code which includes:
      * 0 - The type of tag (as described below) for the op code.
      * 1 - The beginning line in the first sequence.
      * 2 - The end line in the first sequence.
@@ -366,12 +358,10 @@ class SequenceMatcher
     }
 
     /**
-     * Return a nested set of arrays for all of the matching sub-sequences
-     * in the strings $a and $b.
+     * Return a nested set of arrays for all of the matching sub-sequences in compared strings $a and $b.
      *
-     * Each block contains the lower constraint of the block in $a, the lower
-     * constraint of the block in $b and finally the number of lines that the
-     * block continues for.
+     * Each block contains the lower constraint of the block in $a, the lower constraint of the block in $b and finally
+     * the number of lines that the block continues for.
      *
      * @return array Nested array of the matching blocks, as described by the function.
      */

--- a/tests/Diff/SequenceMatcherTest.php
+++ b/tests/Diff/SequenceMatcherTest.php
@@ -84,7 +84,7 @@ class SequenceMatcherTest extends TestCase
     }
 
     /**
-     *T est the opCodes of the differences between version1 and version2 with option ignoreCase enabled.
+     * Test the opCodes of the differences between version1 and version2 with option ignoreCase enabled.
      */
     public function testGetGroupedOpCodesIgnoreCaseTrue()
     {
@@ -96,5 +96,53 @@ class SequenceMatcherTest extends TestCase
         );
 
         $this->assertEquals([], $sequenceMatcher->getGroupedOpCodes());
+    }
+
+    /**
+     * Test the opCodes of the differences between version1 and version2 with option ignoreLines set to empty.
+     */
+    public function testGetGroupedOpCodesIgnoreLinesEmpty()
+    {
+        // Test with ignoreCase enabled. Both sequences are considered to be the same.
+        $sequenceMatcher = new SequenceMatcher(
+            [0, 1, 2, 3],
+            [0, 1, '', 2, 3],
+            ['ignoreLines' => SequenceMatcher::DIFF_IGNORE_LINE_EMPTY]
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    ['equal', 0, 2, 0, 2],
+                    ['ignore', 2, 2, 2, 3],
+                    ['equal', 2, 4, 3, 5],
+                ],
+            ],
+            $sequenceMatcher->getGroupedOpCodes()
+        );
+    }
+
+    /**
+     * Test the opCodes of the differences between version1 and version2 with option ignoreLines set to blank.
+     */
+    public function testGetGroupedOpCodesIgnoreLinesBlank()
+    {
+        // Test with ignoreCase enabled. Both sequences are considered to be the same.
+        $sequenceMatcher = new SequenceMatcher(
+            [0, 1, 2, 3],
+            [0, 1, "\t", 2, 3],
+            ['ignoreLines' => SequenceMatcher::DIFF_IGNORE_LINE_BLANK]
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    ['equal', 0, 2, 0, 2],
+                    ['ignore', 2, 2, 2, 3],
+                    ['equal', 2, 4, 3, 5],
+                ],
+            ],
+            $sequenceMatcher->getGroupedOpCodes()
+        );
     }
 }


### PR DESCRIPTION
Proof of concept - Ignore blank lines.

Adds option `IgnoreLines` which accepts 3 levels:
0 (or any other value): Don't ignore blank lines.
1: Ignore empty lines.
2: Ignore blank lines. (Contains no or only whitespace characters).

Please note the script spawns errors.
At this moment, ignoring lines is only implemented for the HTML SideBySide renderer.

Once this feature operates as expected, it can be extended to the other renderers.