### PR TITLE
Keep "Out Of Context" lines in opCodes

### DIFF
--- a/lib/jblond/Diff/ConstantsInterface.php
+++ b/lib/jblond/Diff/ConstantsInterface.php
@@ -27,7 +27,7 @@ interface ConstantsInterface
      */
     public const DIFF_IGNORE_LINE_EMPTY = 1;
     /**
-     * Flag to ignore blank lines. (Lines which contain no or only non printable characters.)
+     * Flag to ignore blank lines. (Lines which contain no or only non-printable characters.)
      */
     public const DIFF_IGNORE_LINE_BLANK = 2;
 }

--- a/lib/jblond/Diff/Renderer/Html/Merged.php
+++ b/lib/jblond/Diff/Renderer/Html/Merged.php
@@ -97,9 +97,9 @@ HTML;
     /**
      * @inheritDoc
      *
-     * @return string Representation of skipped lines.
+     * @return string HTML code representing table rows showing text which is 'Out Of Context'
      */
-    public function generateSkippedLines(): string
+    public function generateLinesOutOfContext($change): string
     {
         $marker      = '&hellip;';
         $headerClass = '';

--- a/lib/jblond/Diff/Renderer/Html/SideBySide.php
+++ b/lib/jblond/Diff/Renderer/Html/SideBySide.php
@@ -86,9 +86,9 @@ HTML;
     /**
      * @inheritDoc
      *
-     * @return string HTML code representation of a table's header.
+     * @return string HTML code representing table rows showing text which is "Out Of Context"
      */
-    public function generateSkippedLines(): string
+    public function generateLinesOutOfContext($change): string
     {
         return <<<HTML
 <tr>

--- a/lib/jblond/Diff/Renderer/Html/Unified.php
+++ b/lib/jblond/Diff/Renderer/Html/Unified.php
@@ -87,9 +87,9 @@ HTML;
     /**
      * @inheritDoc
      *
-     * @return string HTML code representation of skipped lines.
+     * @return string HTML code representing table rows showing text which is 'Out Of Context'
      */
-    public function generateSkippedLines(): string
+    public function generateLinesOutOfContext($change): string
     {
         return <<<HTML
 <tr>

--- a/lib/jblond/Diff/Renderer/Html/Unified.php
+++ b/lib/jblond/Diff/Renderer/Html/Unified.php
@@ -222,7 +222,7 @@ HTML;
     /**
      * @inheritDoc
      *
-     * @return string Html code representing table rows showing modified text.
+     * @return string Html code representing table rows showing ignored text.
      */
     public function generateLinesIgnore(array $changes): string
     {

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -429,7 +429,7 @@ class MainRenderer extends MainRendererAbstract
     }
 
     /**
-     * Format a series of strings which are suitable for output in a HTML rendered diff.
+     * Format a series of strings which are suitable for output in an HTML rendered diff.
      *
      * This involves replacing tab characters with spaces, making the HTML safe for output by ensuring that double
      * spaces are replaced with &nbsp; etc.

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -37,12 +37,13 @@ class MainRenderer extends MainRendererAbstract
      *
      * This method is called by the renderers which extends this class.
      *
-     * @param   array   $changes      Contains the op-codes about the differences between version1 and version2.
-     * @param   object  $subRenderer  Renderer which is subClass of this class.
+     * @param   array                 $changes      Contains the op-codes about the differences between version1 and
+     *                                              version2.
+     * @param   SubRendererInterface  $subRenderer  Renderer which is child class of this class.
      *
      * @return string|false String representation of the differences or false when versions are identical.
      */
-    public function renderOutput(array $changes, object $subRenderer)
+    public function renderOutput(array $changes, SubRendererInterface $subRenderer)
     {
         if (!$changes) {
             //No changes between version1 and version2

--- a/lib/jblond/Diff/Renderer/MainRenderer.php
+++ b/lib/jblond/Diff/Renderer/MainRenderer.php
@@ -51,13 +51,7 @@ class MainRenderer extends MainRendererAbstract
 
         $output = $subRenderer->generateDiffHeader();
 
-        foreach ($changes as $iterator => $blocks) {
-            if ($iterator > 0) {
-                // If this is a separate block, we're condensing code to indicate a significant portion of the code
-                // has been collapsed as it did not change.
-                $output .= $subRenderer->generateSkippedLines();
-            }
-
+        foreach ($changes as $blocks) {
             $this->maxLineMarkerWidth = max(
                 strlen($this->options['insertMarkers'][0]),
                 strlen($this->options['deleteMarkers'][0]),
@@ -99,6 +93,10 @@ class MainRenderer extends MainRendererAbstract
                     case 'ignore':
                         // TODO: Keep backward compatible with renderers?
                         $output .= $subRenderer->generateLinesIgnore($change);
+                        break;
+                    case 'outOfContext':
+                        // TODO: Keep backward compatible with renderers?
+                        $output .= $subRenderer->generateLinesOutOfContext($change);
                         break;
                 }
 
@@ -335,17 +333,15 @@ class MainRenderer extends MainRendererAbstract
             // Changes between the lines exist.
             // Add markers around the changed character sequence in the old string.
             $sequenceEnd = mb_strlen($oldString) + $end;
-            $oldString
-                         = mb_substr($oldString, 0, $start) . "\0" .
-                mb_substr($oldString, $start, $sequenceEnd - $start) . "\1" .
-                mb_substr($oldString, $sequenceEnd);
+            $oldString   = mb_substr($oldString, 0, $start) . "\0" .
+                           mb_substr($oldString, $start, $sequenceEnd - $start) . "\1" .
+                           mb_substr($oldString, $sequenceEnd);
 
             // Add markers around the changed character sequence in the new string.
             $sequenceEnd = mb_strlen($newString) + $end;
-            $newString
-                         = mb_substr($newString, 0, $start) . "\0" .
-                mb_substr($newString, $start, $sequenceEnd - $start) . "\1" .
-                mb_substr($newString, $sequenceEnd);
+            $newString   = mb_substr($newString, 0, $start) . "\0" .
+                           mb_substr($newString, $start, $sequenceEnd - $start) . "\1" .
+                           mb_substr($newString, $sequenceEnd);
 
             // Overwrite the strings in the old and new text so the changed lines include the markers.
             $oldText[$startOld + $iterator] = $oldString;
@@ -397,7 +393,7 @@ class MainRenderer extends MainRendererAbstract
 
     /**
      * Helper function that will fill the changes-array for the renderer with default values.
-     * Every time an operation changes (specified by $tag) , a new element will be appended to this array.
+     * Every time an operation changes (specified by $tag), a new element will be appended to this array.
      *
      * The index of the last element of the array is always returned.
      *

--- a/lib/jblond/Diff/Renderer/SubRendererInterface.php
+++ b/lib/jblond/Diff/Renderer/SubRendererInterface.php
@@ -63,11 +63,11 @@ interface SubRendererInterface
     public function generateLinesInsert(array $changes): string;
 
     /**
-     * Generate a string representation of lines that are skipped in the diff view.
+     * Generate a string representation of lines that are "Out Of Context" for the diff view.
      *
-     * @return string Representation of skipped lines.
+     * @return string Representation of 'Out Of Context' lines.
      */
-    public function generateSkippedLines(): string;
+    public function generateLinesOutOfContext($change): string;
 
     /**
      * Generate a string representation of lines with ignored differences between both versions.

--- a/lib/jblond/Diff/Renderer/Text/Context.php
+++ b/lib/jblond/Diff/Renderer/Text/Context.php
@@ -51,10 +51,10 @@ class Context extends MainRendererAbstract
             }
             $diff     .= "***************\n";
             $lastItem = array_key_last($group);
-            $start1   = $group['0']['1'];
-            $end1     = $group[$lastItem]['2'];
-            $start2   = $group['0']['3'];
-            $end2     = $group[$lastItem]['4'];
+            $start1   = $group[0][1];
+            $end1     = $group[$lastItem][2];
+            $start2   = $group[0][3];
+            $end2     = $group[$lastItem][4];
 
             // Line to line header for version 1.
             $diffStart = $end1 - $start1 >= 2 ? $start1 + 1 . ',' : '';

--- a/lib/jblond/Diff/Renderer/Text/Context.php
+++ b/lib/jblond/Diff/Renderer/Text/Context.php
@@ -44,9 +44,13 @@ class Context extends MainRendererAbstract
         $diff    = false;
         $opCodes = $this->diff->getGroupedOpCodes();
 
-        foreach ($opCodes as $group) {
+        foreach ($opCodes as $key => $group) {
+            if ($key % 2) {
+                // Skip lines which are Out Of Context.
+                continue;
+            }
             $diff     .= "***************\n";
-            $lastItem = count($group) - 1;
+            $lastItem = array_key_last($group);
             $start1   = $group['0']['1'];
             $end1     = $group[$lastItem]['2'];
             $start2   = $group['0']['3'];

--- a/lib/jblond/Diff/Renderer/Text/InlineCli.php
+++ b/lib/jblond/Diff/Renderer/Text/InlineCli.php
@@ -77,9 +77,9 @@ class InlineCli extends MainRenderer implements SubRendererInterface
     /**
      * @inheritDoc
      *
-     * @return string Representation of skipped lines.
+     * @return string HTML code representing table rows showing text which is 'Out Of Context'
      */
-    public function generateSkippedLines(): string
+    public function generateLinesOutOfContext($change): string
     {
         return "...\n";
     }

--- a/lib/jblond/Diff/Renderer/Text/Unified.php
+++ b/lib/jblond/Diff/Renderer/Text/Unified.php
@@ -40,10 +40,10 @@ class Unified extends MainRendererAbstract
                 continue;
             }
             $lastItem = array_key_last($group);
-            $i1       = $group['0']['1'];
-            $i2       = $group[$lastItem]['2'];
-            $j1       = $group['0']['3'];
-            $j2       = $group[$lastItem]['4'];
+            $i1       = $group[0][1];
+            $i2       = $group[$lastItem][2];
+            $j1       = $group[0][3];
+            $j2       = $group[$lastItem][4];
 
             if ($i1 == 0 && $i2 == 0) {
                 $i1 = -1;

--- a/lib/jblond/Diff/Renderer/Text/Unified.php
+++ b/lib/jblond/Diff/Renderer/Text/Unified.php
@@ -34,8 +34,12 @@ class Unified extends MainRendererAbstract
     {
         $diff    = false;
         $opCodes = $this->diff->getGroupedOpCodes();
-        foreach ($opCodes as $group) {
-            $lastItem = count($group) - 1;
+        foreach ($opCodes as $key => $group) {
+            if ($key % 2) {
+                // Skip lines which are Out Of Context.
+                continue;
+            }
+            $lastItem = array_key_last($group);
             $i1       = $group['0']['1'];
             $i2       = $group[$lastItem]['2'];
             $j1       = $group['0']['3'];

--- a/lib/jblond/Diff/Renderer/Text/UnifiedCli.php
+++ b/lib/jblond/Diff/Renderer/Text/UnifiedCli.php
@@ -66,8 +66,12 @@ class UnifiedCli extends MainRendererAbstract
     {
         $diff    = '';
         $opCodes = $this->diff->getGroupedOpCodes();
-        foreach ($opCodes as $group) {
-            $lastItem = count($group) - 1;
+        foreach ($opCodes as $key => $group) {
+            if ($key % 2) {
+                // Skip lines which are Out Of Context.
+                continue;
+            }
+            $lastItem = array_key_last($group);
             $i1       = $group['0']['1'];
             $i2       = $group[$lastItem]['2'];
             $j1       = $group['0']['3'];
@@ -82,6 +86,7 @@ class UnifiedCli extends MainRendererAbstract
                 '@@ -' . ($i1 + 1) . ',' . ($i2 - $i1) . ' +' . ($j1 + 1) . ',' . ($j2 - $j1) . " @@\n",
                 'purple'
             );
+
             foreach ($group as [$tag, $i1, $i2, $j1, $j2]) {
                 if ($tag == 'equal') {
                     $string = implode(
@@ -112,8 +117,8 @@ class UnifiedCli extends MainRendererAbstract
     }
 
     /**
-     * @param string $string
-     * @param string $color
+     * @param   string  $string
+     * @param   string  $color
      *
      * @return string
      */

--- a/lib/jblond/Diff/Renderer/Text/UnifiedCli.php
+++ b/lib/jblond/Diff/Renderer/Text/UnifiedCli.php
@@ -72,10 +72,10 @@ class UnifiedCli extends MainRendererAbstract
                 continue;
             }
             $lastItem = array_key_last($group);
-            $i1       = $group['0']['1'];
-            $i2       = $group[$lastItem]['2'];
-            $j1       = $group['0']['3'];
-            $j2       = $group[$lastItem]['4'];
+            $i1       = $group[0][1];
+            $i2       = $group[$lastItem][2];
+            $j1       = $group[0][3];
+            $j2       = $group[$lastItem][4];
 
             if ($i1 == 0 && $i2 == 0) {
                 $i1 = -1;

--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -437,11 +437,6 @@ class SequenceMatcher implements ConstantsInterface
         $matchingBlocks = [];
         while (!empty($queue)) {
             [$aLower, $aUpper, $bLower, $bUpper] = array_pop($queue);
-            /**
-             * @noinspection PhpStrictTypeCheckingInspection
-             * $aLower, $aUpper, $bLower, $bUpper reported as wrong type because of multiple definitions of function
-             * count above.
-             */
             $longestMatch = $this->findLongestMatch($aLower, $aUpper, $bLower, $bUpper);
             [$list1, $list2, $list3] = $longestMatch;
             if ($list3) {

--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -115,6 +115,7 @@ class SequenceMatcher implements ConstantsInterface
      *
      * @param   string|array  $version1  A string or array containing the lines to compare against.
      * @param   string|array  $version2  A string or array containing the lines to compare.
+     *
      * @return void
      */
     public function setSequences($version1, $version2): void
@@ -129,6 +130,7 @@ class SequenceMatcher implements ConstantsInterface
      * Also resets internal caches to indicate that, when calling the calculation methods, we need to recalculate them.
      *
      * @param   string|array|void  $version1  The sequence to set as the first sequence.
+     *
      * @return void
      */
     public function setSeq1($version1): void
@@ -150,7 +152,8 @@ class SequenceMatcher implements ConstantsInterface
      *
      * Also resets internal caches to indicate that, when calling the calculation methods, we need to recalculate them.
      *
-     * @param  string|array  $version2  The sequence to set as the second sequence.
+     * @param   string|array  $version2  The sequence to set as the second sequence.
+     *
      * @return void
      */
     public function setSeq2($version2): void
@@ -186,9 +189,11 @@ class SequenceMatcher implements ConstantsInterface
                     unset($this->b2j[$char]);
                     continue;
                 }
+
                 $this->b2j[$char][] = $i;
                 continue;
             }
+
             $this->b2j[$char] = [$i];
         }
 
@@ -216,49 +221,34 @@ class SequenceMatcher implements ConstantsInterface
     }
 
     /**
-     * Return a series of nested arrays containing different groups of generated
-     * op codes for the differences between the strings with up to $this->options['context'] lines
-     * of surrounding content.
+     * Return a series of nested arrays containing different groups of generated op codes for the differences between
+     * the strings with up to $this->options['context'] lines of surrounding content.
      *
-     * Essentially what happens here is any big equal blocks of strings are stripped
-     * out, the smaller subsets of changes are then arranged in to their groups.
-     * This means that the sequence matcher and diffs do not need to include the full
-     * content of the different files but can still provide context as to where the
-     * changes are.
+     * Any large equal block of strings is separated into smaller subsets which are "Within- or Out Of Context".
      *
      * @return array Nested array of all the grouped op codes.
      */
     public function getGroupedOpCodes(): array
     {
         $opCodes = $this->getOpCodes();
-        if (empty($opCodes)) {
-            $opCodes = [
-                [
-                    'equal',
-                    0,
-                    1,
-                    0,
-                    1,
-                ],
-            ];
-        }
+        $opCodes = $opCodes ?: [['equal', 0, 1, 0, 1,],];
 
         if ($this->options['trimEqual']) {
-            if ($opCodes['0']['0'] == 'equal') {
-                // Remove sequences at the start of the text, but keep the context lines.
-                $opCodes['0'] = [
-                    $opCodes['0']['0'],
-                    max($opCodes['0']['1'], $opCodes['0']['2'] - $this->options['context']),
-                    $opCodes['0']['2'],
-                    max($opCodes['0']['3'], $opCodes['0']['4'] - $this->options['context']),
-                    $opCodes['0']['4'],
+            if ($opCodes[0][0] == 'equal') {
+                // Remove equal sequences at the start of the text, but keep the context lines.
+                $opCodes[0] = [
+                    $opCodes[0][0],
+                    max($opCodes[0][1], $opCodes[0][2] - $this->options['context']),
+                    $opCodes[0][2],
+                    max($opCodes[0][3], $opCodes[0][4] - $this->options['context']),
+                    $opCodes[0][4],
                 ];
             }
 
-            $lastItem = count($opCodes) - 1;
-            if ($opCodes[$lastItem]['0'] == 'equal') {
+            $lastItem = array_key_last($opCodes);
+            if ($opCodes[$lastItem][0] == 'equal') {
+                // Remove equal sequences at the end of the text, but keep the context lines.
                 [$tag, $item1, $item2, $item3, $item4] = $opCodes[$lastItem];
-                // Remove sequences at the end of the text, but keep the context lines.
                 $opCodes[$lastItem] = [
                     $tag,
                     $item1,
@@ -271,35 +261,49 @@ class SequenceMatcher implements ConstantsInterface
 
         $maxRange = $this->options['context'] * 2;
         $groups   = [];
-        $group    = [];
+        $newGroup = [];
 
         foreach ($opCodes as [$tag, $item1, $item2, $item3, $item4]) {
             if ($tag == 'equal' && $item2 - $item1 > $maxRange) {
-                $group[]  = [
+                // Count of equal lines is greater than defined maximum context.
+                // Define lines before "Out of Context".
+                $newGroup[] = [
                     $tag,
                     $item1,
                     min($item2, $item1 + $this->options['context']),
                     $item3,
                     min($item4, $item3 + $this->options['context']),
                 ];
-                $groups[] = $group;
-                $group    = [];
+
+                $groups[] = $newGroup;
+
+                // Define lines which are "Out Of Context".
+                $newGroup   = [];
+                $newGroup[] = [
+                    'outOfContext',
+                    min($item2, $item1 + $this->options['context']),
+                    max($item1, $item2 - $this->options['context']),
+                    min($item4, $item3 + $this->options['context']),
+                    max($item3, $item4 - $this->options['context']),
+                ];
+                $groups[]   = $newGroup;
+
+                // Define start of lines after "Out Of Context".
+                $newGroup = [];
                 $item1    = max($item1, $item2 - $this->options['context']);
                 $item3    = max($item3, $item4 - $this->options['context']);
             }
 
-            $group[] = [
-                $tag,
-                $item1,
-                $item2,
-                $item3,
-                $item4,
-            ];
+            // Define lines "Within Context".
+            $newGroup[] = [$tag, $item1, $item2, $item3, $item4,];
         }
 
-        if (!$this->options['trimEqual'] || (!empty($group) && !(count($group) == 1 && $group[0][0] == 'equal'))) {
+        if (
+            !$this->options['trimEqual'] ||
+            (!empty($newGroup) && !(count($newGroup) == 1 && $newGroup[0][0] == 'equal'))
+        ) {
             // Add the last sequences when !trimEqual || When there are no differences between both versions.
-            $groups[] = $group;
+            $groups[] = $newGroup;
         }
 
         return $groups;

--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -51,12 +51,12 @@ class SequenceMatcher implements ConstantsInterface
      */
     private $b2j = [];
     /**
-     * @var array A list of all of the op-codes for the differences between the compared strings.
+     * @var array A list of all the op-codes for the differences between the compared strings.
      */
     private $opCodes;
 
     /**
-     * @var array A nested set of arrays for all of the matching sub-sequences the compared strings.
+     * @var array A nested set of arrays for all the matching sub-sequences the compared strings.
      */
     private $matchingBlocks;
 
@@ -623,8 +623,8 @@ class SequenceMatcher implements ConstantsInterface
     /**
      * Check if the two lines at the given indexes are different or not.
      *
-     * @param   int  $aIndex  Line number to check against in a.
-     * @param   int  $bIndex  Line number to check against in b.
+     * @param   int  $aIndex  Number of line to check against in A.
+     * @param   int  $bIndex  Number of line to check against in B.
      *
      * @return bool True if the lines are different and false if not.
      */

--- a/lib/jblond/Diff/Similarity.php
+++ b/lib/jblond/Diff/Similarity.php
@@ -71,7 +71,7 @@ class Similarity extends SequenceMatcher
     public function getSimilarity(int $type = self::CALC_DEFAULT): float
     {
         if ($this->options['ignoreLines']) {
-            // Backup original sequences and filter non blank lines.
+            // Backup original sequences and filter non-blank lines.
             $this->stripLines();
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     colors="true"
     bootstrap="vendor/autoload.php"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory>./lib</directory>

--- a/tests/Diff/SequenceMatcherTest.php
+++ b/tests/Diff/SequenceMatcherTest.php
@@ -59,7 +59,9 @@ class SequenceMatcherTest extends TestCase
         $this->assertEquals(
             [
                 [['equal', 0, 3, 0, 3]],
+                [['outOfContext', 3, 4, 3, 4]],
                 [['equal', 4, 7, 4, 7], ['replace', 7, 8, 7, 8], ['equal', 8, 11, 8, 11]],
+                [['outOfContext', 11, 12, 11, 12]],
                 [['equal', 12, 15, 12, 15]],
             ],
             $sequenceMatcher->getGroupedOpCodes()

--- a/tests/resources/htmlMerged.txt
+++ b/tests/resources/htmlMerged.txt
@@ -71,10 +71,10 @@
 </tr><tr>
     <th class="" title="">22</th>
     <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</td>
-</tr></tbody><tr>
+</tr></tbody><tbody class="ChangeOutOfContext"><tr>
     <th class="" title="">&hellip;</th>
     <td class="Skipped">&hellip;</td>
-</tr><tbody class="ChangeEqual"><tr>
+</tr></tbody><tbody class="ChangeEqual"><tr>
     <th class="" title="">25</th>
     <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</td>
 </tr><tr>

--- a/tests/resources/htmlSideBySide.txt
+++ b/tests/resources/htmlSideBySide.txt
@@ -207,12 +207,12 @@
     <td class="Right">
         <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</span>
     </td>
-</tr></tbody><tr>
+</tr></tbody><tbody class="ChangeOutOfContext"><tr>
     <th>&hellip;</th>
     <td class="Left Skipped">&hellip;</td>
     <th>&hellip;</th>
     <td class="Right Skipped">&hellip;</td>
-</tr><tbody class="ChangeEqual"><tr>
+</tr></tbody><tbody class="ChangeEqual"><tr>
     <th>25</th>
     <td class="Left">
         <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</span>

--- a/tests/resources/htmlUnified.txt
+++ b/tests/resources/htmlUnified.txt
@@ -151,11 +151,11 @@
     <th>22</th>
     <th>22</th>
     <td class="Left">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</td>
-</tr></tbody><tr>
+</tr></tbody><tbody class="ChangeOutOfContext"><tr>
     <th>&hellip;</th>
     <th>&hellip;</th>
     <td class="Left Skipped">&hellip;</td>
-</tr><tbody class="ChangeEqual"><tr>
+</tr></tbody><tbody class="ChangeEqual"><tr>
     <th>25</th>
     <th>25</th>
     <td class="Left">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Just some lines to demonstrate the collapsing of a block of lines which are the same in both versions.&lt;/p&gt;</td>


### PR DESCRIPTION
Instead of removing the lines which are out of context from the opCodes,
They're now kept in the opCodes, but tagged as "outOfContext".

This replaces the `generateLinesSkipped()` methods of the renderers.

Other changes present like small fixes, code reformatting, etc.