### PR TITLE
Fix #125 - Make str_split multibyte save

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require": {
         "php": ">=7.3",
         "ext-mbstring": "*",
-        "ext-pcre": "*"
+        "ext-pcre": "*",
+        "symfony/polyfill-mbstring": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8 || ^9",

--- a/lib/jblond/Diff/SequenceMatcher.php
+++ b/lib/jblond/Diff/SequenceMatcher.php
@@ -136,7 +136,7 @@ class SequenceMatcher implements ConstantsInterface
     public function setSeq1($version1): void
     {
         if (!is_array($version1)) {
-            $version1 = str_split($version1);
+            $version1 = mb_str_split($version1);
         }
         if ($version1 == $this->old) {
             return;
@@ -159,7 +159,7 @@ class SequenceMatcher implements ConstantsInterface
     public function setSeq2($version2): void
     {
         if (!is_array($version2)) {
-            $version2 = str_split($version2);
+            $version2 = mb_str_split($version2);
         }
         if ($version2 == $this->new) {
             return;


### PR DESCRIPTION
str_split() will split into bytes, rather than characters when dealing
with a multi-byte encoded string. Use mb_str_split() to split the string
into code points.

mb_str_split() is available as of php 7.4.0.
This library supports php >=7.3.0.
mb_str_split() added to the library as a symfony polyfill function.